### PR TITLE
Form para cargar crucigrama personalizado

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,11 +75,43 @@
           class="container-sm" 
           id="references">
         </div>
+
         <br>
-        <!-- Contenedor JSON Crucigrama -->
+        <!-- Contenedor Crucigrama Personalizado -->
         <div class="container-sm" id="crossword-code">
           <h3>Crucigrama personalizado</h3>
           <p>A continuación, puede modificar el contenido del crucigrama (formato JSON) y generar uno personalizado:</p>
+          <!-- Formulario para crear crucigrama -->
+          <form 
+              class="container-sm" 
+              id="cpuzzle-custom">
+            <div class="row">
+              <div class="col">
+                <input 
+                    type="text"
+                    class="form-control"
+                    placeholder="Palabra vertical (pista)"
+                    id="txt-vword"
+                    aria-describedby="crosswordsGenBlock">
+                <small 
+                  id="crosswordsGenBlock" 
+                  class="form-text text-muted">
+                  En el crucigrama de ejemplo, la palabra vertical es "FREUD".
+                </small>
+              </div>
+              <div class="col">
+                  <input 
+                      type="button" 
+                      class="form-control btn btn-primary" 
+                      id="btn-restart" 
+                      value="🚀 ¡Vamos!" 
+                      onclick="generateFormLoadCustomCrossword()"/>
+              </div>
+            </div>
+          </form>
+          
+          <br>
+          <!-- Formulario para crear crucigrama con JSON -->
           <form 
             class="container-sm" 
             id="cpuzzle-code">

--- a/index.html
+++ b/index.html
@@ -80,7 +80,9 @@
         <!-- Contenedor Crucigrama Personalizado -->
         <div class="container-sm">
           <h3>Crucigrama personalizado</h3>
-          <p>A continuación, puede modificar el contenido del crucigrama (formato JSON) y generar uno personalizado:</p>
+          <p>A continuación, podés generar tu propio crucigrama, con las palabras que vos elijas.
+            <br>Primero, ingresá cuál va a ser la palabra a mostrar de manera vertical:
+          </p>
           <!-- Formulario para crear crucigrama -->
           <form 
               class="container-sm" 

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
               class="btn btn-primary" 
               id="btn-restart" 
               value="🚀 Cargar" 
-              onclick="restart()"/>
+              onclick="loadFromJSON()"/>
           </form>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
 
         <br>
         <!-- Contenedor Crucigrama Personalizado -->
-        <div class="container-sm" id="crossword-code">
+        <div class="container-sm">
           <h3>Crucigrama personalizado</h3>
           <p>A continuación, puede modificar el contenido del crucigrama (formato JSON) y generar uno personalizado:</p>
           <!-- Formulario para crear crucigrama -->
@@ -91,6 +91,7 @@
                     type="text"
                     class="form-control"
                     placeholder="Palabra vertical (pista)"
+                    value="FREUD"
                     id="txt-vword"
                     aria-describedby="crosswordsGenBlock">
                 <small 
@@ -103,15 +104,22 @@
                   <input 
                       type="button" 
                       class="form-control btn btn-primary" 
-                      id="btn-restart" 
+                      id="btn-loadGenForm" 
                       value="🚀 ¡Vamos!" 
                       onclick="generateFormLoadCustomCrossword()"/>
               </div>
             </div>
+            <div id="cpuzzle-generator-container">
+            </div>
           </form>
           
           <br>
+        </div>  
           <!-- Formulario para crear crucigrama con JSON -->
+        <div
+          class="container-sm"
+          id="crossword-code"
+          style="visibility: hidden;">
           <form 
             class="container-sm" 
             id="cpuzzle-code">
@@ -148,8 +156,6 @@
         </div>
     </div>
     
-    
-
     <!-- Pie de página -->
     <footer>
       2024 - Mariela Montaldo.

--- a/scripts/crossword-puzzle.js
+++ b/scripts/crossword-puzzle.js
@@ -35,6 +35,7 @@ _refs = [];
 // Declaración de constantes
 const CPUZZLE_CONTAINER = document.getElementById('cpuzzle');
 const REFERENCES_CONTAINER = document.getElementById('references');
+const GENERATOR_CONTAINER = document.getElementById('cpuzzle-generator-container');
 const JSONPUZZLE_INPUT = document.getElementById('jsonpuzzle');
 
 // Constantes globales
@@ -155,6 +156,65 @@ function printCrossword() {
 function showAnswers() {
     CPUZZLE_CONTAINER.innerHTML = '';
     drawCrossword(_vword, _answers, true);
+}
+
+function generateFormLoadCustomCrossword() {
+    let VWORD_INPUT = document.getElementById('txt-vword');
+    let vword = VWORD_INPUT.value.toUpperCase();
+    if(vword) 
+    {
+        for(i = 0; i < vword.length; i++)
+        {
+            let data = `
+                <div class="row">
+                    <div class="col">
+                        <input 
+                            type="text"
+                            class="form-control"
+                            placeholder="Palabra que contenga la letra ${vword[i]} (respuesta, palabra #${i + 1})."
+                            value=""
+                            id="txt-hword-${i}">
+                    </div>
+                    <div class="col">
+                        <input 
+                            type="text"
+                            class="form-control"
+                            placeholder="Referencia para la palabra #${i + 1} que contiene la letra ${vword[i]}"
+                            value=""
+                            id="txt-refs-${i}">
+                    </div>
+                </div>
+                `;
+            GENERATOR_CONTAINER.innerHTML += data;
+        }
+        GENERATOR_CONTAINER.innerHTML +=
+        `<div class="row">
+            <div class="col">
+                <input 
+                    type="button" 
+                    class="form-control btn btn-secondary" 
+                    id="btn-jsonForm" 
+                    value="Prefiero generarlo insertando un JSON" 
+                    onclick="showJsonForm()"/>
+            </div>
+            <div class="col">
+                <input 
+                    type="button" 
+                    class="form-control btn btn-primary" 
+                    id="btn-generateForm" 
+                    value="¡Listo! Generar crucigrama" 
+                    onclick="generateCustomCrossword()"/>
+            </div>
+        </div>`;
+    } else {
+        alert('Algo no anduvo bien... ¿Cargaste la palabra vertical?');
+        VWORD_INPUT.focus();
+    }
+}
+
+function showJsonForm() {
+    const jform = document.getElementById('crossword-code');
+    jform.style.visibility = "visible" ;
 }
 
 // Función llamadora - Principal

--- a/scripts/crossword-puzzle.js
+++ b/scripts/crossword-puzzle.js
@@ -26,15 +26,24 @@
 *
 * ========================================================================================
 */
+
+// Declaración de variables globales
 _answers = [];
 _vword = "";
 _refs = [];
-_size = 36;
-_half = 18;
+
+// Declaración de constantes
+const CPUZZLE_CONTAINER = document.getElementById('cpuzzle');
+const REFERENCES_CONTAINER = document.getElementById('references');
+const JSONPUZZLE_INPUT = document.getElementById('jsonpuzzle');
+
+// Constantes globales
+const _SIZE = 36;
+const _HALF = 18;
 
 function preloadCrossword() {
     var json_arr = {};
-    json_arr = JSON.parse(document.getElementById('jsonpuzzle').value);
+    json_arr = JSON.parse(JSONPUZZLE_INPUT.value);
     _answers = json_arr[0]["answers"];
     _vword = json_arr[0]["vword"];
     _refs = json_arr[0]["refs"];
@@ -42,7 +51,6 @@ function preloadCrossword() {
 
 // Dibujar el crucigrama
 function drawCrossword (vword, ans, showAnswers) {
-    const container = document.getElementById('cpuzzle');
     let html = '<form><table class="table table-borderless">';
     
     // i es contador para cantidad de letras de la palabra vertical (filas del crucigrama)
@@ -50,20 +58,39 @@ function drawCrossword (vword, ans, showAnswers) {
         html += '<tr>';
         
         // pos inicial y final donde se empiezan a escribir las palabras en la fila horizontal
-        let initPosition = Math.max(0, _half - ans[i].toLowerCase().indexOf(vword[i].toLowerCase()));
+        let initPosition = Math.max(0, _HALF - ans[i].toLowerCase().indexOf(vword[i].toLowerCase()));
 
         // c contador para letras de las palabras horizontales
         let c = 0;
         let color = false;
         
         // j contador para espacios horizontales (vacíos o con letras, es indistinto)
-        for(j = 0; j < _size; j++) {
+        for(j = 0; j < _SIZE; j++) {
             if(j >= initPosition && j < initPosition + ans[i].length) {
                 if(ans[i][j - initPosition].toLowerCase() == vword[i].toLowerCase() && !color) {
-                    html += `<td class="table-primary" id="clueword"><input type="text" size="1" maxlength="1" readonly="readonly" value="${ans[i][c].toUpperCase()}" /></td>`;
+                    html += `<td 
+                                class="table-primary" 
+                                id="clueword">
+                                <input 
+                                    type="text" 
+                                    size="1" 
+                                    maxlength="1" 
+                                    readonly="readonly" 
+                                    value="${ans[i][c].toUpperCase()}" />
+                            </td>`;
                     color = true;
                 } else {
-                    html += `<td class="table-secondary"><input type="text" id="txt-${i}-${c}" onkeyup="validateChar(${i},${c})" class="form-control no-border" size="1" maxlength="1" value="${(showAnswers == true ? ans[i][c] : "")}"/></td>`;
+                    html += `<td 
+                                class="table-secondary">
+                                    <input 
+                                        type="text" 
+                                        id="txt-${i}-${c}" 
+                                        onkeyup="validateChar(${i},${c})" 
+                                        class="form-control no-border" 
+                                        size="1" 
+                                        maxlength="1" 
+                                        value="${(showAnswers == true ? ans[i][c] : "")}"/>
+                            </td>`;
                 }
                 c++;
             } else {
@@ -72,14 +99,14 @@ function drawCrossword (vword, ans, showAnswers) {
         }
         html += `</tr>`;
     }
-    container.innerHTML = html + `</table></form>`;
+    CPUZZLE_CONTAINER.innerHTML = html + `</table></form>`;
 }
 
 function setCrosswordReferences(descriptions, container) {
     let cont = document.getElementById(container);
     cont.innerHTML += `<h3>Referencias</h3><ol>`;
     for(s of descriptions) {
-        cont.innerHTML += `<li style="display: list-item;">${s}</li>`;
+        cont.innerHTML += `<li>${s}</li>`;
     }
     cont.innerHTML += `</ol>`;
 }
@@ -99,24 +126,24 @@ function validateChar(i, c) {
 }
 
 function restart() {
-    document.getElementById('references').innerHTML = '';
-    document.getElementById('cpuzzle').innerHTML = '';
+    REFERENCES_CONTAINER.innerHTML = '';
+    CPUZZLE_CONTAINER.innerHTML = '';
     runCPuzzle();
     alert('¡Listo!');
 }
 
 function printCrossword() {
-    document.getElementById('references').innerHTML = '';
-    document.getElementById('cpuzzle').innerHTML = '';
+    REFERENCES_CONTAINER.innerHTML = '';
+    CPUZZLE_CONTAINER.innerHTML = '';
     runCPuzzle();
     let data = `
         <html>
             <head>
-                <title>Crucigrama | ${((_vword) ? _vword : '')} </title>
+                <title>Crucigrama | ${((_vword) ? _vword : '')}</title>
             </head>
         <body>` 
-        + document.getElementById('cpuzzle').innerHTML
-        + document.getElementById('references').innerHTML
+        + CPUZZLE_CONTAINER.innerHTML
+        + REFERENCES_CONTAINER.innerHTML
         + ` </body>
             </html>`;
     const printableWindow = window.open('', '_blank');
@@ -126,7 +153,7 @@ function printCrossword() {
 }
 
 function showAnswers() {
-    document.getElementById('cpuzzle').innerHTML = '';
+    CPUZZLE_CONTAINER.innerHTML = '';
     drawCrossword(_vword, _answers, true);
 }
 

--- a/scripts/crossword-puzzle.js
+++ b/scripts/crossword-puzzle.js
@@ -57,7 +57,6 @@ function drawCrossword (vword, ans, showAnswers) {
     // i es contador para cantidad de letras de la palabra vertical (filas del crucigrama)
     for(i=0; i < ans.length; i++) {
         html += '<tr>';
-        
         // pos inicial y final donde se empiezan a escribir las palabras en la fila horizontal
         let initPosition = Math.max(0, _HALF - ans[i].toLowerCase().indexOf(vword[i].toLowerCase()));
 
@@ -129,14 +128,29 @@ function validateChar(i, c) {
 function restart() {
     REFERENCES_CONTAINER.innerHTML = '';
     CPUZZLE_CONTAINER.innerHTML = '';
-    runCPuzzle();
+    drawCrossword(_vword, _answers, false);
+    setCrosswordReferences(_refs, "references");
+    alert('¡Listo!');
+}
+
+function loadFromJSON() {
+    var json_arr = {};
+    json_arr = JSON.parse(JSONPUZZLE_INPUT.value);
+    _answers = json_arr[0]["answers"];
+    _vword = json_arr[0]["vword"];
+    _refs = json_arr[0]["refs"];
+    REFERENCES_CONTAINER.innerHTML = '';
+    CPUZZLE_CONTAINER.innerHTML = '';
+    drawCrossword(_vword, _answers, false);
+    setCrosswordReferences(_refs, "references");
     alert('¡Listo!');
 }
 
 function printCrossword() {
     REFERENCES_CONTAINER.innerHTML = '';
     CPUZZLE_CONTAINER.innerHTML = '';
-    runCPuzzle();
+    drawCrossword(_vword, _answers, false);
+    setCrosswordReferences(_refs, "references");
     let data = `
         <html>
             <head>
@@ -217,9 +231,27 @@ function showJsonForm() {
     jform.style.visibility = "visible" ;
 }
 
+function generateCustomCrossword() {
+    let VWORD_INPUT = document.getElementById('txt-vword');
+    let vword = VWORD_INPUT.value.toUpperCase();
+    _vword = vword;
+    _answers = [];
+    _refs = [];
+    for(i = 0; i < vword.length; i++)
+    {
+        let ans = document.getElementById(`txt-hword-${i}`).value.toLowerCase();
+        let ref = document.getElementById(`txt-refs-${i}`).value;
+        _answers.push(ans);
+        _refs.push(ref);
+    }
+    drawCrossword(vword, _answers, false);
+    REFERENCES_CONTAINER.innerHTML = '';
+    setCrosswordReferences(_refs, "references");
+}
+
 // Función llamadora - Principal
 function runCPuzzle() {
-    preloadCrossword();
+    preloadCrossword(); // Cambiar esto al inicio, a la carga del documento x 1ra vez
     drawCrossword(_vword, _answers, false);
     setCrosswordReferences(_refs, "references");
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a3ee3fee-a82f-4214-bf8d-e1448422b3a2)

Incorpora un formulario, haciendo más amena la experiencia de usuario al permitirle generar su crucigrama personalizado sin tener que cargar un JSON (aunque también se mantiene esta alternativa, para usuarios con cierto nivel de conocimiento técnico que así lo prefieran). Posteriormente, el usuario va a poder imprimir el crucigrama generado por él mismo.